### PR TITLE
logrotate: fix permissions

### DIFF
--- a/root/etc/logrotate.d/nethcti
+++ b/root/etc/logrotate.d/nethcti
@@ -3,7 +3,7 @@
    rotate 10
    compress
    weekly
-   create 0644 asterisk asterisk
+   create 0640 asterisk asterisk
    postrotate
        /usr/bin/systemctl reload nethcti-server &> /dev/null
    endscript


### PR DESCRIPTION
Rotated logs should not be readable by everyone

NethServer/dev#5411