### PR TITLE
logrotate: avoid warning and respect system config

### DIFF
--- a/root/etc/logrotate.d/nethcti
+++ b/root/etc/logrotate.d/nethcti
@@ -1,9 +1,7 @@
 /var/log/asterisk/nethcti.log {
    missingok
-   rotate 10
-   compress
-   weekly
    create 0640 asterisk asterisk
+   sharedscripts
    postrotate
        /usr/bin/systemctl reload nethcti-server &> /dev/null
    endscript


### PR DESCRIPTION
- remove 'rotate', 'compress' and 'weekly' option: they are intherithed from system-wide
configuration
- add 'sharedscripts' option: avoid cron mails complaining about nethcti restart

Suppressed warning:

 error: error running non-shared postrotate script for /var/log/asterisk/nethcti.log of '/var/log/asterisk/nethcti.log '