### PR TITLE
Fix: ws clients do not receive queue update events in case of shibboleth login

### DIFF
--- a/root/usr/lib/node/nethcti-server/plugins/com_nethcti_ws/com_nethcti_ws.js
+++ b/root/usr/lib/node/nethcti-server/plugins/com_nethcti_ws/com_nethcti_ws.js
@@ -2241,6 +2241,9 @@ function doLogin(socket, obj) {
     sendAutheSuccess(socket);
 
     var username = astProxy.isExten(obj.accessKeyId) ? compUser.getUserUsingEndpointExtension(obj.accessKeyId) : obj.accessKeyId;
+    if (compAuthe.isShibbolethUser(username)) {
+      username = compAuthe.getShibbolethUsername(username);
+    }
 
     // if the user has the "presence panel" permission, than he will receive
     // the asterisk events that involve the extensions


### PR DESCRIPTION
When the CTI uses the Shibboleth login, when the user makes a login, the server does not add him to websocket rooms to receive queue update events.
This is because cti server check user permission using shibboleth id instead of username.
So the fix is very simple: 
- check if the user is a shibboleth id
- in case use the right username associated with shibboleth id