### PR TITLE
authentication template: fix perl warning

### DIFF
--- a/root/etc/e-smith/templates/etc/nethcti/authentication.json/10base
+++ b/root/etc/e-smith/templates/etc/nethcti/authentication.json/10base
@@ -2,7 +2,7 @@
     use esmith::NetworksDB;
     my $unautheCall = ${'nethcti-server'}{'UnautheCall'} || "disabled";
     my $allowedIp = ${'nethcti-server'}{'UnautheCallAddress'} || esmith::NetworksDB->local_access_spec();
-    my $autheEnabled = ${'nethcti-server'}{'AuthenticationEnabled'} || false;
+    my $autheEnabled = ${'nethcti-server'}{'AuthenticationEnabled'} || "false";
 
     $OUT = '{
     "enabled": ' . $autheEnabled . ',


### PR DESCRIPTION
Avoid warning on template expansion:
WARNING in /etc/e-smith/templates//etc/nethcti/authentication.json/10base: Unquoted string "false" may clash with future reserved word