### PR TITLE
fix proxyLogic to set mac of extensions

### DIFF
--- a/root/usr/lib/node/nethcti-server/plugins/astproxy/proxy_logic_13/proxy_logic_13.js
+++ b/root/usr/lib/node/nethcti-server/plugins/astproxy/proxy_logic_13/proxy_logic_13.js
@@ -2962,6 +2962,7 @@ function initializePjsipExten(err, results) {
       }
       let extenId = results[e].ext;
       objToUse[extenId] = new Extension(extenId, 'pjsip');
+      objToUse[extenId].setMac(macDataByExt[extenId] ? macDataByExt[extenId] : '');
       parallelOp[extenId] = [];
       parallelOp[extenId].push(getDndExten(extenId));
       parallelOp[extenId].push(getCfExten(extenId));


### PR DESCRIPTION
The set of mac of extensions was lost during last merge conflicts resolutions.
