### PR TITLE
Fix post-restore-config failure

### DIFF
--- a/root/usr/lib/systemd/system/nethcti-server.service
+++ b/root/usr/lib/systemd/system/nethcti-server.service
@@ -2,6 +2,8 @@
 Description=NethCTI server daemon
 Wants=asterisk.service
 After=asterisk.service
+ConditionPathExists=/etc/nethcti/nethcti.json
+ConditionPathExists=/etc/nethcti/asterisk.json
 
 [Service]
 Type=simple


### PR DESCRIPTION
The `nethcti-server` service reload in the `trusted-networks-modify` event triggers a chain of early services startup (namely: MariaDB, Asterisk).

As they are still not configured correctly the whole restore-config fails.

Avoid the service startup until it is completely configured.

https://github.com/nethesis/dev/issues/5885