### PR TITLE
nethcti.json template: fix field type

### DIFF
--- a/root/etc/e-smith/templates/etc/nethcti/nethcti.json/10base
+++ b/root/etc/e-smith/templates/etc/nethcti/nethcti.json/10base
@@ -6,7 +6,7 @@
   my $proxy_status = ${'flexisip-proxy'}{'status'} || "disabled";
   my $proxy_port = undef;
   if ($proxy_status eq 'enabled') {
-      $proxy_port = ${'flexisip-proxy'}{'TCPPorts'} || "6061";
+      $proxy_port = int(${'flexisip-proxy'}{'TCPPorts'}) || 6061;
   }
 
   my $json = JSON->new;


### PR DESCRIPTION
The javascript code expects that port field is an integer.
This change enforce perl type casting.

Nethesis/dev#5904