### PR TITLE
Change Fanvil call action url

### DIFF
--- a/root/etc/e-smith/templates/etc/nethcti/phone_urls.json/10base
+++ b/root/etc/e-smith/templates/etc/nethcti/phone_urls.json/10base
@@ -41,7 +41,7 @@
     },
     "^fanvil.*": {
         "urls": {
-            "call": "http://$PHONE_USER:$PHONE_PASS@$PHONE_IP/cgi-bin/ConfigManApp.com?key=F_HEADSET;$NUMBER;ENTER",
+            "call": "http://$PHONE_USER:$PHONE_PASS@$PHONE_IP/cgi-bin/ConfigManApp.com?key=$NUMBER;ENTER",
             "answer": "http://$PHONE_USER:$PHONE_PASS@$PHONE_IP/cgi-bin/ConfigManApp.com?key=OK",
             "hold_unhold": "http://$PHONE_USER:$PHONE_PASS@$PHONE_IP/cgi-bin/ConfigManApp.com?key=F_HOLD",
             "dtmf": "http://$PHONE_USER:$PHONE_PASS@$PHONE_IP/cgi-bin/ConfigManApp.com?key=$TONE"


### PR DESCRIPTION
Use generic action URL, without specifying HEADSET, to make a call for Fanvil phones because we cannot assume that everyone has headphones connected.