### PR TITLE
Fix configuration files permissions

### DIFF
--- a/nethcti-server.spec
+++ b/nethcti-server.spec
@@ -66,7 +66,7 @@ rm -rf %{buildroot}
 --dir /var/lib/nethserver/nethcti/templates/customer_card 'attr(0775,asterisk,asterisk)' \
 --dir /usr/lib/node/nethcti-server/plugins/com_static_http/static 'attr(0775,asterisk,asterisk)' \
 --dir /var/lib/asterisk/sounds/nethcti 'attr(0775,asterisk,asterisk)' \
---dir /etc/nethcti/dbstatic.d 'attr(0775,asterisk,asterisk)' \
+--dir /etc/nethcti/dbstatic.d 'attr(0770,asterisk,asterisk)' \
 --dir /etc/nethcti 'attr(0775,asterisk,asterisk)' > %{name}-%{version}-filelist
 
 %clean

--- a/root/etc/e-smith/templates.metadata/etc/nethcti/asterisk.json
+++ b/root/etc/e-smith/templates.metadata/etc/nethcti/asterisk.json
@@ -1,0 +1,3 @@
+PERMS=0660
+UID="asterisk"
+GID="asterisk"

--- a/root/etc/e-smith/templates.metadata/etc/nethcti/dbstatic.d/nethcti3.json
+++ b/root/etc/e-smith/templates.metadata/etc/nethcti/dbstatic.d/nethcti3.json
@@ -1,0 +1,3 @@
+PERMS=0660
+UID="asterisk"
+GID="asterisk"

--- a/root/etc/e-smith/templates.metadata/etc/nethcti/dbstatic.d/phonebook.json
+++ b/root/etc/e-smith/templates.metadata/etc/nethcti/dbstatic.d/phonebook.json
@@ -1,0 +1,3 @@
+PERMS=0660
+UID="asterisk"
+GID="asterisk"


### PR DESCRIPTION
Fix permission of database configuration files using templates metadata: they were world readable and contains database credentials