### PR TITLE
Add maximum number of daily connected users to facter

### DIFF
--- a/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/nethcti.rb
+++ b/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/nethcti.rb
@@ -8,6 +8,12 @@ Facter.add('nethcti') do
     if ! tmp.empty?
         nethcti = JSON.parse(tmp)
     end
+    tmp = Facter::Core::Execution.exec('ls -tr /var/log/asterisk/nethcti.log* | tail -n2 | xargs zgrep -a "^$(date +%Y-%m-%d --date="yesterday")T.*wsid conn [0-9]*$" | rev | cut -d" " -f1 | rev | sort -n | tail -n1 2>/dev/null')
+    if ! tmp.empty?
+        nethcti['conn_clients']['daily_max_ws_conn_clients'] = tmp
+    else
+        nethcti['conn_clients']['daily_max_ws_conn_clients'] = 0
+    end
 
     nethcti
   end


### PR DESCRIPTION
conn_clients->ws_conn_clients contains number of connected users when facter is launched, that is during night.
With this new conn_clients->daily_max_ws_conn_clients, the maximum number of connected user in the previous day is collected.