### PR TITLE
Don't show calls answered by someone else as lost

### DIFF
--- a/root/usr/lib/node/nethcti-server/plugins/dbconn/plugins/dbconn_history.js
+++ b/root/usr/lib/node/nethcti-server/plugins/dbconn/plugins/dbconn_history.js
@@ -445,7 +445,8 @@ function getHistorySwitchCallInterval(data, cb) {
         'cnum IN ' + data.extens + ' AND ' +
         'dst IN ' + data.extens + ' AND ' +
         '(calldate>=? AND calldate<=?) AND ' +
-        '(cnum LIKE ? OR clid LIKE ? OR dst LIKE ? OR cnam LIKE ? OR ccompany LIKE ? OR dst_cnam LIKE ? OR dst_ccompany LIKE ?)',
+        '(cnum LIKE ? OR clid LIKE ? OR dst LIKE ? OR cnam LIKE ? OR ccompany LIKE ? OR dst_cnam LIKE ? OR dst_ccompany LIKE ?) ' +
+        'AND (disposition NOT IN ("NO ANSWER","BUSY","FAILED") OR (disposition IN ("NO ANSWER","BUSY","FAILED") AND linkedid NOT IN (SELECT uniqueid FROM cdr AS b WHERE disposition = "ANSWERED" AND b.uniqueid = cdr.linkedid)))',
         data.trunks, data.trunks,
         data.from, data.to,
         "%" + data.filter + "%", "%" + data.filter + "%", "%" + data.filter + "%", "%" + data.filter + "%", "%" + data.filter + "%",


### PR DESCRIPTION
Also `History -> Switchboard calls -> internal` has same problem
https://github.com/nethesis/dev/issues/6161