### PR TITLE
Fix external script launcher comment

### DIFF
--- a/root/usr/lib/node/nethcti-server/plugins/exec_script/exec_script.js
+++ b/root/usr/lib/node/nethcti-server/plugins/exec_script/exec_script.js
@@ -199,6 +199,7 @@ function setAstProxyListeners() {
  *  @param {string} data.billableseconds    The number of seconds between the answer and end times for the call
  *  @param {string} data.destinationcontext The destination context for the call
  *  @param {string} data.destinationchannel The called party’s channel
+ *  @param {string} data.accountcode        The accountcode of the caller
  */
 function evtNewCdr(data) {
   try {


### PR DESCRIPTION
Last parameter was missing and it is the accountcode of the caller