### PR TITLE
Add new endpoints to provide persistent tokens for the phone island

### DIFF
--- a/root/usr/lib/node/nethcti-server/plugins/authentication/arch_authentication.js
+++ b/root/usr/lib/node/nethcti-server/plugins/authentication/arch_authentication.js
@@ -49,6 +49,7 @@ module.exports = function(options, imports, register) {
       isUnautheCallEnabled: authentication.isUnautheCallEnabled,
       getShibbolethUsername: authentication.getShibbolethUsername,
       removePersistentToken: authentication.removePersistentToken,
+      persistentTokenExists: authentication.persistentTokenExists,
       isUnautheCallIPEnabled: authentication.isUnautheCallIPEnabled,
       authenticateRemoteSite: authentication.authenticateRemoteSite,
       isAutoUpdateTokenExpires: authentication.isAutoUpdateTokenExpires,

--- a/root/usr/lib/node/nethcti-server/plugins/com_authentication_rest/plugins_rest/authentication.js
+++ b/root/usr/lib/node/nethcti-server/plugins/com_authentication_rest/plugins_rest/authentication.js
@@ -220,7 +220,9 @@ function setCompUser(comp) {
       // the REST api
       api: {
         'root': 'authentication',
-        'get': [],
+        'get': [
+          'phone_island_token_check'
+        ],
 
         /**
          * REST API to be requested using HTTP POST request.
@@ -244,7 +246,8 @@ function setCompUser(comp) {
           'login',
           'remotelogin',
           'logout',
-          'phone_island_token'
+          'phone_island_token_login',
+          'persistent_token_remove'
         ],
         'head': [],
         'del': []
@@ -345,18 +348,17 @@ function setCompUser(comp) {
       /**
        * Provides the login function for the phone island with the following REST API:
        *
-       *     phone_island_token
+       *     phone_island_token_login
        *
        * Every user with a valid token can invoke it and receive an API token without expiration
        * There is only a persistent phone island token for each user
        *
-       * @method phone_island_token
+       * @method phone_island_token_login
        * @param {object}   req  The client request
        * @param {object}   res  The client response
-       * @param {function} next Function to run the next handler in the chain
        * @return The token without expiration and the username
        */
-       phone_island_token: async function(req, res) {
+       phone_island_token_login: async function(req, res) {
         try {
 
           // Get the username from the headers
@@ -365,17 +367,93 @@ function setCompUser(comp) {
           // The token validity is checked inside the authorization proxy
           const authToken = req.headers.authorization_token;
 
-          // Add _phone_island to the end of api username tokens
-          const apiUsername = `${username}_phone_island`
+          // Add _phone-island to the end of api username tokens
+          const apiUsername = `${username}_phone-island`;
 
           // Create the persistent token using username and a valid authentication token
           const apiToken = await compAuthe.getPersistentToken(apiUsername, authToken);
           // Return the token ready to be used by api's and ws
           res.send(200, {
-            api_token: apiToken,
+            token: apiToken,
             username: username
           });
 
+        } catch (err) {
+          logger.log.error(IDLOG, err.stack);
+          compUtil.net.sendHttp401(IDLOG, err);
+        }
+      },
+
+      /**
+       * Checks if the phone island token was already created REST API:
+       *
+       *     phone_island_token_check
+       *
+       * @method phone_island_token_check
+       * @param {object}   req  The client request
+       * @param {object}   res  The client response
+       * @return An object containing a boolean exists property
+       */
+       phone_island_token_check: async function(req, res) {
+        try {
+
+          // Get the username from the headers
+          const username = req.headers.authorization_user;
+
+          // Add _phone-island to the end of api username tokens
+          const islandUsername = `${username}_phone-island`;
+
+          // Check if the persistent token exists
+          const exists = await compAuthe.persistentTokenExists(islandUsername);
+          // Return the true if exists or false
+          res.send(200, {
+            exists: exists,
+          });
+
+        } catch (err) {
+          logger.log.error(IDLOG, err.stack);
+          compUtil.net.sendHttp401(IDLOG, err);
+        }
+      },
+
+      /**
+       * Provides the api to revoke a persistent token
+       * 
+       *    persistent_token_remove
+       * 
+       * @param {object} req The client request
+       * @param {object} res The client response
+       */
+      persistent_token_remove: async function(req, res) {
+        try {
+          // Check parameters
+          if (req.params.type !== 'phone-island' && req.params.type !== 'no-exp') {
+            throw new Error('wrong parameters: ' + JSON.stringify(arguments));
+          }
+
+          // Get the username from the headers
+          const username = req.headers.authorization_user;
+          // Get the token from the headers
+          const token = req.headers.authorization_token;
+
+          // Init target username to be revoked
+          let userToRevoke = '';
+
+          // Set target username to be revoked
+          if (req.params.type === 'phone-island') {
+            userToRevoke = `${username}_phone-island`;
+          } else if (req.params.type === 'no-exp') {
+            userToRevoke = username;
+          }
+          // Remove the persistent token using the username
+          const removed = await compAuthe.removePersistentToken(userToRevoke, token, req.params.type);
+
+          if (removed) {
+            // Return the token ready to be used by api's and ws
+            res.send(200, {});
+          } else {
+            throw new Error(`persistent token of type ${req.params.type} not removed for user: ${username}`);
+          }
         } catch (err) {
           logger.log.error(IDLOG, err.stack);
           compUtil.net.sendHttp401(IDLOG, err);
@@ -392,12 +470,12 @@ function setCompUser(comp) {
        * @param {object}   res  The client response
        * @param {function} next Function to run the next handler in the chain
        */
-      logout: function(req, res, next) {
+      logout: async function(req, res, next) {
         try {
           var token = req.headers.authorization_token;
           var username = req.headers.authorization_user;
           var authExpiration = req.headers["auth-exp"];
-          var isLoggedOut = (authExpiration === "no-exp") ? (compAuthe.removePersistentToken(username, token) === true) : (compAuthe.removeToken(username, token) === true);
+          var isLoggedOut = (authExpiration === "no-exp") ? (await compAuthe.removePersistentToken(username, token, 'no-exp') === true) : (compAuthe.removeToken(username, token) === true);
           if (isLoggedOut) {
             logger.log.info(IDLOG, 'user "' + username + '" successfully logged out');
             compUtil.net.sendHttp200(IDLOG, res);
@@ -416,7 +494,9 @@ function setCompUser(comp) {
     exports.api = authentication.api;
     exports.login = authentication.login;
     exports.logout = authentication.logout;
-    exports.phone_island_token = authentication.phone_island_token;
+    exports.phone_island_token_login = authentication.phone_island_token_login;
+    exports.persistent_token_remove = authentication.persistent_token_remove;
+    exports.phone_island_token_check = authentication.phone_island_token_check;
     exports.setLogger = setLogger;
     exports.setCompUtil = setCompUtil;
     exports.setCompUser = setCompUser;


### PR DESCRIPTION
Add persistent token for phone island component.
Add 3 new apis for the token manegement:
- POST phone_island_token_login - Creates the token
- GET phone_island_token_check - Checks if the token exists
- POST persistent_token_remove - Removes a token based on type ```phone-island``` or ```no-exp```

See UI part https://github.com/nethesis/nethvoice-cti/pull/27/files