### PR TITLE
Fix phone-island authentication username check

### DIFF
--- a/root/usr/lib/node/nethcti-server/plugins/authentication/authentication.js
+++ b/root/usr/lib/node/nethcti-server/plugins/authentication/authentication.js
@@ -1270,7 +1270,7 @@ function verifyToken(username, token, isRemote) {
     }
 
     // check the grant presence
-    if (!grants[username] && !persistentTokens.has(username)) {
+    if (!grants[username] && !persistentTokens.has(username) && !persistentTokens.has(`${username}_phone-island`)) {
       logger.log.warn(IDLOG, 'authentication failed for ' + (isRemote ? 'remote site ' : 'local ') + 'username: "' + username + '": no grant is present');
       return false;
     }


### PR DESCRIPTION
The authentication fail when the username is missing from grants and persistent tokens and the phone-island token check is skipped. The check of the phone-island username in persistent tokens must be add.