### PR TITLE
dbconn. dbconn_history: added grouped history calls

### DIFF
--- a/root/usr/lib/node/nethcti-server/plugins/com_history_rest/plugins_rest/histcallsgroups.js
+++ b/root/usr/lib/node/nethcti-server/plugins/com_history_rest/plugins_rest/histcallsgroups.js
@@ -360,6 +360,9 @@ function setCompAuthorization(ca) {
           if (req.params.removeLostCalls) {
             obj.removeLostCalls = req.params.removeLostCalls;
           }
+          if (req.params.grouped) {
+            obj.grouped = (req.params.grouped === 'true');
+          }
 
           // if the user has the privacy enabled, it adds the privacy string to be used to hide the phone numbers
           if (compAuthorization.isPrivacyEnabled(username)) {

--- a/root/usr/lib/node/nethcti-server/plugins/com_history_rest/plugins_rest/histcallswitch.js
+++ b/root/usr/lib/node/nethcti-server/plugins/com_history_rest/plugins_rest/histcallswitch.js
@@ -312,6 +312,9 @@ function setCompAuthorization(ca) {
           if (req.params.removeLostCalls) {
             obj.removeLostCalls = req.params.removeLostCalls;
           }
+          if (req.params.grouped) {
+            obj.grouped = (req.params.grouped === 'true');
+          }
 
           // if the user has the privacy enabled, it adds the privacy string to be used to hide the phone numbers
           if (compAuthorization.isPrivacyEnabled(username)) {

--- a/root/usr/lib/node/nethcti-server/plugins/com_history_rest/plugins_rest/historycall.js
+++ b/root/usr/lib/node/nethcti-server/plugins/com_history_rest/plugins_rest/historycall.js
@@ -752,6 +752,9 @@ function setCompAuthorization(ca) {
           if (req.params.removeLostCalls) {
             obj.removeLostCalls = req.params.removeLostCalls;
           }
+          if (req.params.grouped) {
+            obj.grouped = (req.params.grouped === 'true');
+          }
 
           // use the history component
           compHistory.getHistoryCallInterval(obj, function(err1, results) {

--- a/root/usr/lib/node/nethcti-server/plugins/com_history_rest/plugins_rest/historycall.js
+++ b/root/usr/lib/node/nethcti-server/plugins/com_history_rest/plugins_rest/historycall.js
@@ -752,9 +752,6 @@ function setCompAuthorization(ca) {
           if (req.params.removeLostCalls) {
             obj.removeLostCalls = req.params.removeLostCalls;
           }
-          if (req.params.grouped) {
-            obj.grouped = (req.params.grouped === 'true');
-          }
 
           // use the history component
           compHistory.getHistoryCallInterval(obj, function(err1, results) {

--- a/root/usr/lib/node/nethcti-server/plugins/dbconn/plugins/dbconn_history.js
+++ b/root/usr/lib/node/nethcti-server/plugins/dbconn/plugins/dbconn_history.js
@@ -156,6 +156,8 @@ function getHistoryCallInterval(data, cb) {
 
     // define the mysql field to be returned. The "recordingfile" field
     // is returned only if the "data.recording" argument is true
+    // grouped is used to visualize call grouped, useful the see
+    // how calls inside queues are managed
     if(data.grouped) {
       var attributes = [
         ['UNIX_TIMESTAMP(MIN(calldate))', 'time'],

--- a/root/usr/lib/node/nethcti-server/plugins/dbconn/plugins/dbconn_history.js
+++ b/root/usr/lib/node/nethcti-server/plugins/dbconn/plugins/dbconn_history.js
@@ -162,8 +162,6 @@ function getHistoryCallInterval(data, cb) {
       ['MAX(duration)','duration'], ['IF (MIN(disposition) = "ANSWERED", MAX(billsec), MIN(billsec))','billsec'],
       'disposition', 'dcontext', 'lastapp'
     ];
-
-
     if (data.recording === true) {
       attributes.push('recordingfile');
     }
@@ -190,7 +188,6 @@ function getHistoryCallInterval(data, cb) {
       attributes.push('dst_cnam');
       attributes.push('dst_ccompany');
       attributes.push('clid');
-
     }
 
     // add "direction" ("in" | "out" | "lost" | "") based on data.endpoints presence on "src" and "dst"
@@ -280,8 +277,7 @@ function getHistoryCallInterval(data, cb) {
       offset: (data.offset ? parseInt(data.offset) : 0),
       limit: (data.limit ? parseInt(data.limit) : null),
       group: ['uniqueid','linkedid','disposition'],
-      order: (data.sort ? data.sort : 'time desc'),
-      logging: logger.log.error
+      order: (data.sort ? data.sort : 'time desc')
     }).then(function(results) {
       compDbconnMain.models[compDbconnMain.JSON_KEYS.HISTORY_CALL].count({
           where: whereClause,
@@ -553,7 +549,7 @@ function getHistorySwitchCallInterval(data, cb) {
       limit: (data.limit ? parseInt(data.limit) : null),
       group: data.grouped ? ['linkedid'] : ['uniqueid','linkedid','disposition'],
       order: (data.sort ? data.sort : 'time desc'),
-      logging: logger.log.error,
+      logging: logger.log.error
     }).then(function(results) {
       compDbconnMain.models[compDbconnMain.JSON_KEYS.HISTORY_CALL].count({
           where: whereClause,

--- a/root/usr/lib/node/nethcti-server/plugins/dbconn/plugins/dbconn_history.js
+++ b/root/usr/lib/node/nethcti-server/plugins/dbconn/plugins/dbconn_history.js
@@ -156,12 +156,29 @@ function getHistoryCallInterval(data, cb) {
 
     // define the mysql field to be returned. The "recordingfile" field
     // is returned only if the "data.recording" argument is true
-    var attributes = [
-      ['UNIX_TIMESTAMP(calldate)', 'time'],
-      'channel', 'dstchannel', 'uniqueid', 'linkedid', 'userfield',
-      ['MAX(duration)','duration'], ['IF (MIN(disposition) = "ANSWERED", MAX(billsec), MIN(billsec))','billsec'],
-      'disposition', 'dcontext', 'lastapp'
-    ];
+    if(data.grouped) {
+      var attributes = [
+        ['UNIX_TIMESTAMP(MIN(calldate))', 'time'],
+        ['(select channel from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'channel'],
+        ['(select dstchannel from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'dstchannel'],
+        ['MIN(uniqueid)', 'uniqueid'],
+        'linkedid',
+        'userfield',
+        ['MAX(duration)','duration'],
+        ['COALESCE(MAX(CASE WHEN disposition = "ANSWERED" AND lastapp = "Dial" THEN billsec ELSE 0 END), (select billsec from cdr b where b.calldate = MIN(cdr.calldate) and disposition = "ANSWERED" limit 1), MIN(billsec))','billsec'],
+        ['CASE WHEN MIN(disposition) = "ANSWERED" THEN MIN(disposition) ELSE (select disposition from cdr b where b.calldate = MIN(cdr.calldate) limit 1) END', 'disposition'],
+        ['(select dcontext from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'dcontext'],
+        ['(select lastapp from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'lastapp']
+      ];
+    } else {
+      var attributes = [
+        ['UNIX_TIMESTAMP(calldate)', 'time'],
+        'channel', 'dstchannel', 'uniqueid', 'linkedid', 'userfield',
+        ['MAX(duration)','duration'], ['IF (MIN(disposition) = "ANSWERED", MAX(billsec), MIN(billsec))','billsec'],
+        'disposition', 'dcontext', 'lastapp'
+      ];
+    }
+
     if (data.recording === true) {
       attributes.push('recordingfile');
     }
@@ -169,25 +186,46 @@ function getHistoryCallInterval(data, cb) {
     // if the privacy string is present, than hide the numbers
     if (data.privacyStr) {
       // the numbers are hidden
-      attributes.push(['CONCAT( SUBSTRING(cnum, 1, LENGTH(cnum) - ' + data.privacyStr.length + '), "' + data.privacyStr + '")', 'cnum']);
-      attributes.push(['CONCAT( SUBSTRING(src, 1, LENGTH(src) - ' + data.privacyStr.length + '), "' + data.privacyStr + '")', 'src']);
-      attributes.push(['CONCAT( SUBSTRING(dst, 1, LENGTH(dst) - ' + data.privacyStr.length + '), "' + data.privacyStr + '")', 'dst']);
-      attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'cnam']);
-      attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'clid']);
-      attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'ccompany']);
-      attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'dst_cnam']);
-      attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'dst_ccompany']);
-
+      if(data.grouped) {
+        attributes.push(['(select CONCAT( SUBSTRING(cnum, 1, LENGTH(cnum) - ' + data.privacyStr.length + '), "' + data.privacyStr + '") from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'cnum']);
+        attributes.push(['(select CONCAT( SUBSTRING(src, 1, LENGTH(src) - ' + data.privacyStr.length + '), "' + data.privacyStr + '") from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'src']);
+        attributes.push(['COALESCE(MAX(CASE WHEN disposition = "ANSWERED" AND lastapp = "Dial" THEN dst ELSE NULL END), (select CONCAT( SUBSTRING(dst, 1, LENGTH(dst) - ' + data.privacyStr.length + '), "' + data.privacyStr + '") from cdr b where b.calldate = MIN(cdr.calldate) limit 1))', 'dst']);
+        attributes.push(['(select CONCAT( "", "\\"' + data.privacyStr + '\\"") from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'cnam']);
+        attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'clid']);
+        attributes.push(['(select CONCAT( "", "\\"' + data.privacyStr + '\\"") from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'ccompany']);
+        attributes.push(['COALESCE(MAX(CASE WHEN disposition = "ANSWERED" AND lastapp = "Dial" THEN dst_cnam ELSE NULL END), (select CONCAT( "", "\\"' + data.privacyStr + '\\"") from cdr b where b.calldate = MIN(cdr.calldate) limit 1))', 'dst_cnam']);
+        attributes.push(['COALESCE(MAX(CASE WHEN disposition = "ANSWERED" AND lastapp = "Dial" THEN dst_ccompany ELSE NULL END), (select CONCAT( "", "\\"' + data.privacyStr + '\\"") from cdr b where b.calldate = MIN(cdr.calldate) limit 1) )', 'dst_ccompany']);
+      } else {
+        attributes.push(['CONCAT( SUBSTRING(cnum, 1, LENGTH(cnum) - ' + data.privacyStr.length + '), "' + data.privacyStr + '")', 'cnum']);
+        attributes.push(['CONCAT( SUBSTRING(src, 1, LENGTH(src) - ' + data.privacyStr.length + '), "' + data.privacyStr + '")', 'src']);
+        attributes.push(['CONCAT( SUBSTRING(dst, 1, LENGTH(dst) - ' + data.privacyStr.length + '), "' + data.privacyStr + '")', 'dst']);
+        attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'cnam']);
+        attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'clid']);
+        attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'ccompany']);
+        attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'dst_cnam']);
+        attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'dst_ccompany']);
+      }
     } else {
       // the numbers are clear
-      attributes.push('cnum');
-      attributes.push('cnam');
-      attributes.push('ccompany');
-      attributes.push('src');
-      attributes.push('dst');
-      attributes.push('dst_cnam');
-      attributes.push('dst_ccompany');
-      attributes.push('clid');
+      if(data.grouped) {
+        attributes.push(['(select cnum from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'cnum']);
+        attributes.push(['(select cnam from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'cnam']);
+        attributes.push(['(select ccompany from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'ccompany']);
+        attributes.push(['(select src from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'src']);
+        attributes.push(['COALESCE(MAX(CASE WHEN disposition = "ANSWERED" AND lastapp = "Dial" THEN dst ELSE NULL END), (select dst from cdr b where b.calldate = MIN(cdr.calldate) limit 1))', 'dst']);
+        attributes.push(['COALESCE(MAX(CASE WHEN disposition = "ANSWERED" AND lastapp = "Dial" THEN dst_cnam ELSE NULL END), (select dst_cnam from cdr b where b.calldate = MIN(cdr.calldate) limit 1))', 'dst_cnam']);
+        attributes.push(['COALESCE(MAX(CASE WHEN disposition = "ANSWERED" AND lastapp = "Dial" THEN dst_ccompany ELSE NULL END), (select dst_ccompany from cdr b where b.calldate = MIN(cdr.calldate) limit 1) )', 'dst_ccompany']);
+        attributes.push('clid');
+      } else {
+        attributes.push('cnum');
+        attributes.push('cnam');
+        attributes.push('ccompany');
+        attributes.push('src');
+        attributes.push('dst');
+        attributes.push('dst_cnam');
+        attributes.push('dst_ccompany');
+        attributes.push('clid');
+      }
     }
 
     // add "direction" ("in" | "out" | "lost" | "") based on data.endpoints presence on "src" and "dst"
@@ -276,13 +314,13 @@ function getHistoryCallInterval(data, cb) {
       attributes: attributes,
       offset: (data.offset ? parseInt(data.offset) : 0),
       limit: (data.limit ? parseInt(data.limit) : null),
-      group: ['uniqueid','linkedid','disposition'],
-      order: (data.sort ? data.sort : 'time desc')
-
+      group: data.grouped ? ['uniqueid'] : ['uniqueid','linkedid','disposition'],
+      order: (data.sort ? data.sort : 'time desc'),
+      logging: logger.log.error
     }).then(function(results) {
       compDbconnMain.models[compDbconnMain.JSON_KEYS.HISTORY_CALL].count({
           where: whereClause,
-          group: ['uniqueid','linkedid','disposition'],
+          group: data.grouped ? ['uniqueid'] : ['uniqueid','linkedid','disposition'],
           attributes: attributes
           }).then(function(count) {
               const res = {
@@ -354,11 +392,30 @@ function getHistorySwitchCallInterval(data, cb) {
 
     // define the mysql field to be returned. The "recordingfile" field
     // is returned only if the "data.recording" argument is true
-    var attributes = [
-      ['UNIX_TIMESTAMP(calldate)', 'time'],
-      'channel', 'dstchannel', 'uniqueid', 'linkedid', 'userfield',
-      ['MAX(duration)','duration'], ['IF (MIN(disposition) = "ANSWERED", MAX(billsec), MIN(billsec))','billsec'], 'disposition', 'dcontext', 'lastapp'
-    ];
+    // grouped is used to visualize call grouped, useful the see
+    // how calls inside queues are managed
+    if(data.grouped) {
+      var attributes = [
+        ['UNIX_TIMESTAMP(MIN(calldate))', 'time'],
+        ['(select channel from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'channel'],
+        ['(select dstchannel from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'dstchannel'],
+        ['MIN(uniqueid)', 'uniqueid'],
+        'linkedid',
+        'userfield',
+        ['MAX(duration)','duration'],
+        ['COALESCE(MAX(CASE WHEN disposition = "ANSWERED" AND lastapp = "Dial" THEN billsec ELSE 0 END), (select billsec from cdr b where b.calldate = MIN(cdr.calldate) and disposition = "ANSWERED" limit 1), MIN(billsec))','billsec'],
+        ['CASE WHEN MIN(disposition) = "ANSWERED" THEN MIN(disposition) ELSE (select disposition from cdr b where b.calldate = MIN(cdr.calldate) limit 1) END', 'disposition'],
+        ['(select dcontext from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'dcontext'],
+        ['(select lastapp from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'lastapp']
+      ];
+    } else {
+      var attributes = [
+        ['UNIX_TIMESTAMP(calldate)', 'time'],
+        'channel', 'dstchannel', 'uniqueid', 'linkedid', 'userfield',
+        ['MAX(duration)','duration'], ['IF (MIN(disposition) = "ANSWERED", MAX(billsec), MIN(billsec))','billsec'], 'disposition', 'dcontext', 'lastapp'
+      ];
+    }
+    
     if (data.recording === true) {
       attributes.push('recordingfile');
     }
@@ -370,35 +427,61 @@ function getHistorySwitchCallInterval(data, cb) {
     if (data.trunks.length === 0) {
       data.trunks = '%';
     }
-    attributes.push([compDbconnMain.Sequelize.literal(
-        'IF (dstchannel REGEXP "' + data.trunks + '", "out", ' +
-        '(IF (channel REGEXP "' + data.trunks + '", "in", "internal"))' +
-        ')'),
-      'type'
-    ]);
 
+    if(data.grouped) {
+      attributes.push([compDbconnMain.Sequelize.literal('(select CASE WHEN channel REGEXP "' + data.trunks + '" THEN "in" WHEN dstchannel REGEXP \'' + data.trunks + '\' THEN "out" ELSE "internal" END AS `type` from cdr b where b.calldate = MIN(cdr.calldate) limit 1)'), 'type']);
+    } else {
+      attributes.push([compDbconnMain.Sequelize.literal(
+          'IF (dstchannel REGEXP "' + data.trunks + '", "out", ' +
+          '(IF (channel REGEXP "' + data.trunks + '", "in", "internal"))' +
+          ')'),
+        'type'
+      ]);
+    }
+    
     // if the privacy string is present, than hide the numbers
     if (data.privacyStr) {
       // the numbers are hidden
-      attributes.push(['CONCAT( SUBSTRING(cnum, 1, LENGTH(cnum) - ' + data.privacyStr.length + '), "' + data.privacyStr + '")', 'cnum']);
-      attributes.push(['CONCAT( SUBSTRING(src, 1, LENGTH(src) - ' + data.privacyStr.length + '), "' + data.privacyStr + '")', 'src']);
-      attributes.push(['CONCAT( SUBSTRING(dst, 1, LENGTH(dst) - ' + data.privacyStr.length + '), "' + data.privacyStr + '")', 'dst']);
-      attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'clid']);
-      attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'cnam']);
-      attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'ccompany']);
-      attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'dst_cnam']);
-      attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'dst_ccompany']);
-
+      if(data.grouped) {
+        attributes.push(['(select CONCAT( SUBSTRING(cnum, 1, LENGTH(cnum) - ' + data.privacyStr.length + '), "' + data.privacyStr + '") from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'cnum']);
+        attributes.push(['(select CONCAT( "", "\\"' + data.privacyStr + '\\"") from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'cnam']);
+        attributes.push(['(select CONCAT( "", "\\"' + data.privacyStr + '\\"") from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'ccompany']);
+        attributes.push(['COALESCE(MAX(CASE WHEN disposition = "ANSWERED" AND lastapp = "Dial" THEN dst_cnam ELSE NULL END), (select CONCAT( "", "\\"' + data.privacyStr + '\\"") from cdr b where b.calldate = MIN(cdr.calldate) limit 1))', 'dst_cnam']);
+        attributes.push(['COALESCE(MAX(CASE WHEN disposition = "ANSWERED" AND lastapp = "Dial" THEN dst_ccompany ELSE NULL END), (select CONCAT( "", "\\"' + data.privacyStr + '\\"") from cdr b where b.calldate = MIN(cdr.calldate) limit 1) )', 'dst_ccompany']);
+        attributes.push(['(select CONCAT( SUBSTRING(src, 1, LENGTH(src) - ' + data.privacyStr.length + '), "' + data.privacyStr + '") from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'src']);
+        attributes.push(['COALESCE(MAX(CASE WHEN disposition = "ANSWERED" AND lastapp = "Dial" THEN dst ELSE NULL END), (select CONCAT( SUBSTRING(dst, 1, LENGTH(dst) - ' + data.privacyStr.length + '), "' + data.privacyStr + '") from cdr b where b.calldate = MIN(cdr.calldate) limit 1))', 'dst']);
+        attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'clid']);
+      } else {
+        attributes.push(['CONCAT( SUBSTRING(cnum, 1, LENGTH(cnum) - ' + data.privacyStr.length + '), "' + data.privacyStr + '")', 'cnum']);
+        attributes.push(['CONCAT( SUBSTRING(src, 1, LENGTH(src) - ' + data.privacyStr.length + '), "' + data.privacyStr + '")', 'src']);
+        attributes.push(['CONCAT( SUBSTRING(dst, 1, LENGTH(dst) - ' + data.privacyStr.length + '), "' + data.privacyStr + '")', 'dst']);
+        attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'clid']);
+        attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'cnam']);
+        attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'ccompany']);
+        attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'dst_cnam']);
+        attributes.push(['CONCAT( "", "\\"' + data.privacyStr + '\\"")', 'dst_ccompany']);
+      }
     } else {
       // the numbers are clear
-      attributes.push('cnum');
-      attributes.push('cnam');
-      attributes.push('ccompany');
-      attributes.push('dst_cnam');
-      attributes.push('dst_ccompany');
-      attributes.push('src');
-      attributes.push('dst');
-      attributes.push('clid');
+      if(data.grouped) {
+        attributes.push(['(select cnum from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'cnum']);
+        attributes.push(['(select cnam from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'cnam']);
+        attributes.push(['(select ccompany from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'ccompany']);
+        attributes.push(['COALESCE(MAX(CASE WHEN disposition = "ANSWERED" AND lastapp = "Dial" THEN dst_cnam ELSE NULL END), (select dst_cnam from cdr b where b.calldate = MIN(cdr.calldate) limit 1))', 'dst_cnam']);
+        attributes.push(['COALESCE(MAX(CASE WHEN disposition = "ANSWERED" AND lastapp = "Dial" THEN dst_ccompany ELSE NULL END), (select dst_ccompany from cdr b where b.calldate = MIN(cdr.calldate) limit 1) )', 'dst_ccompany']);
+        attributes.push(['(select src from cdr b where b.calldate = MIN(cdr.calldate) limit 1)', 'src']);
+        attributes.push(['COALESCE(MAX(CASE WHEN disposition = "ANSWERED" AND lastapp = "Dial" THEN dst ELSE NULL END), (select dst from cdr b where b.calldate = MIN(cdr.calldate) limit 1))', 'dst']);
+        attributes.push('clid');
+      } else {
+        attributes.push('cnum');
+        attributes.push('cnam');
+        attributes.push('ccompany');
+        attributes.push('dst_cnam');
+        attributes.push('dst_ccompany');
+        attributes.push('src');
+        attributes.push('dst');
+        attributes.push('clid');
+      }
     }
 
     // check optional parameters
@@ -503,13 +586,13 @@ function getHistorySwitchCallInterval(data, cb) {
       attributes: attributes,
       offset: (data.offset ? parseInt(data.offset) : 0),
       limit: (data.limit ? parseInt(data.limit) : null),
-      group: ['uniqueid','linkedid','disposition'],
-      order: (data.sort ? data.sort : 'time desc')
-
+      group: data.grouped ? ['linkedid'] : ['uniqueid','linkedid','disposition'],
+      order: (data.sort ? data.sort : 'time desc'),
+      logging: logger.log.error,
     }).then(function(results) {
       compDbconnMain.models[compDbconnMain.JSON_KEYS.HISTORY_CALL].count({
           where: whereClause,
-          group: ['uniqueid','linkedid','disposition'],
+          group: data.grouped ? ['linkedid'] : ['uniqueid','linkedid','disposition'],
           attributes: attributes
            }).then(function(count) {
               const res = {

--- a/root/usr/lib/node/nethcti-server/plugins/dbconn/plugins/dbconn_history.js
+++ b/root/usr/lib/node/nethcti-server/plugins/dbconn/plugins/dbconn_history.js
@@ -548,8 +548,7 @@ function getHistorySwitchCallInterval(data, cb) {
       offset: (data.offset ? parseInt(data.offset) : 0),
       limit: (data.limit ? parseInt(data.limit) : null),
       group: data.grouped ? ['linkedid'] : ['uniqueid','linkedid','disposition'],
-      order: (data.sort ? data.sort : 'time desc'),
-      logging: logger.log.error
+      order: (data.sort ? data.sort : 'time desc')
     }).then(function(results) {
       compDbconnMain.models[compDbconnMain.JSON_KEYS.HISTORY_CALL].count({
           where: whereClause,


### PR DESCRIPTION
Added `grouped` attribute to visualize calls grouped, useful the see how calls inside queues are managed.

The params act as a switch:
- if `true` calls are grouped in the new way
- if `false` calls are visualized as usual, without grouping 