### PR TITLE
astproxy: arch_astproxy: take freepbx address from ENV

### DIFF
--- a/root/usr/lib/node/nethcti-server/plugins/astproxy/arch_astproxy.js
+++ b/root/usr/lib/node/nethcti-server/plugins/astproxy/arch_astproxy.js
@@ -602,7 +602,7 @@ module.exports = function(options, imports, register) {
       logger.log.info(IDLOG, `reload config of physical phones ${Object.keys(extens)}`);
       const secretKey = compAuthentication.getAdminSecretKey();
       const options = {
-        hostname: 'localhost',
+        hostname: process.env.NETHVOICE_HOST,
         port: 443,
         path: '',
         method: 'POST',


### PR DESCRIPTION
After configuring your phone on the CTI page, you need to reload your phone to get the new configuration.

To do this the nethcti-server uses the `POST /freepbx/rest/devices/phones/reload/` API to reload the phone.

In this PR we have changed the host from "localhost" to dynamic host provided by the "NETHVOICE_HOST" environment variable.