### PR TITLE
node. pg: update dep to fix connection timeout

### DIFF
--- a/root/usr/lib/node/nethcti-server/package.json
+++ b/root/usr/lib/node/nethcti-server/package.json
@@ -20,7 +20,7 @@
     "node-ipc": "9.1.1",
     "node-static": "0.7.10",
     "nodemailer": "^6.5.0",
-    "pg": "6.1.6",
+    "pg": "8.12.0",
     "request": "2.88.0",
     "restify": "4.3.4",
     "sequelize": "3.34.0",


### PR DESCRIPTION
With version 6.1.6, the connection timeout is not respected and the connection remains queued until the page is refreshed. With this update, pg.Pool works fine.