### PR TITLE
fix: clean up excessive log output from database connection plugin

### DIFF
--- a/root/usr/lib/node/nethcti-server/plugins/dbconn/dbconn_main.js
+++ b/root/usr/lib/node/nethcti-server/plugins/dbconn/dbconn_main.js
@@ -740,6 +740,8 @@ function initMysqlConn(name) {
     // Custom query logging if debug is enabled
     if (logSequelize) {
       const originalQuery = connection.query;
+      const originalExecute = connection.execute;
+
       connection.query = function(sql, values, callback) {
         if (typeof values === 'function') {
           callback = values;
@@ -747,6 +749,15 @@ function initMysqlConn(name) {
         }
         logger.log.info(IDLOG, `MySQL Query [${name}]: ${sql}${values ? ' - Values: ' + JSON.stringify(values) : ''}`);
         return originalQuery.call(this, sql, values, callback);
+      };
+
+      connection.execute = function(sql, values, callback) {
+        if (typeof values === 'function') {
+          callback = values;
+          values = undefined;
+        }
+        logger.log.info(IDLOG, `MySQL Execute [${name}]: ${sql}${values ? ' - Values: ' + JSON.stringify(values) : ''}`);
+        return originalExecute.call(this, sql, values, callback);
       };
     }
     connection.connect(err => {

--- a/root/usr/lib/node/nethcti-server/plugins/dbconn/dbconn_main.js
+++ b/root/usr/lib/node/nethcti-server/plugins/dbconn/dbconn_main.js
@@ -733,9 +733,22 @@ function initMysqlConn(name) {
       user: dbConfig[name].dbuser,
       password: dbConfig[name].dbpassword,
       database: dbConfig[name].dbname,
-      debug: logSequelize,
+      debug: false,
       charset: 'utf8'
     });
+
+    // Custom query logging if debug is enabled
+    if (logSequelize) {
+      const originalQuery = connection.query;
+      connection.query = function(sql, values, callback) {
+        if (typeof values === 'function') {
+          callback = values;
+          values = undefined;
+        }
+        logger.log.info(IDLOG, `MySQL Query [${name}]: ${sql}${values ? ' - Values: ' + JSON.stringify(values) : ''}`);
+        return originalQuery.call(this, sql, values, callback);
+      };
+    }
     connection.connect(err => {
       if (err) {
         logger.log.error(IDLOG, JSON.stringify(err, 2, null));


### PR DESCRIPTION
## Summary

- Disable debug logging for MySQL connections to reduce log pollution
- Maintain custom query logging when debug is explicitly enabled
- Resolves excessive verbose output at info level

Fixes: NethServer/dev#7527