### PR TITLE
fix: use 127.0.0.1 instead of localhost for server binding

### DIFF
--- a/root/usr/lib/node/nethcti-server/plugins/http_proxy/http_proxy.js
+++ b/root/usr/lib/node/nethcti-server/plugins/http_proxy/http_proxy.js
@@ -102,7 +102,7 @@ var port;
  * @readOnly
  * @default "localhost"
  */
-var address = 'localhost';
+var address = '127.0.0.1';
 
 /**
  * The HTTP server to be used with proxy.
@@ -176,6 +176,9 @@ function config(path) {
     port = json.http_proxy.http_port;
   } else {
     logger.log.warn(IDLOG, 'wrong ' + path + ': no "http_port" key into "http_proxy"');
+  }
+  if (json.http_proxy.address) {
+    address = json.http_proxy.address;
   }
   logger.log.info(IDLOG, 'configuration done by ' + path);
 }


### PR DESCRIPTION
## Summary
- Change default bind address from `localhost` to `127.0.0.1` in `http_proxy.js`
- Make the address configurable via `services.json` (`http_proxy.address` key)

On some NS8 machines, `set-fqdn` comments out the IPv4 localhost entry in `/etc/hosts`, leaving only `::1` mapped to `localhost`. This causes the HTTP proxy to bind only on IPv6, making IPv4 connections fail with "connection refused".

Ref: NethServer/dev#7856