### PR TITLE
fix(auth): recover REST listener and close response on errors

### DIFF
--- a/root/usr/lib/node/nethcti-server/plugins/com_authentication_rest/server_com_authentication_rest.js
+++ b/root/usr/lib/node/nethcti-server/plugins/com_authentication_rest/server_com_authentication_rest.js
@@ -414,19 +414,31 @@ function reload() {
 /**
  * Reset the component.
  *
+ * `server.close()` releases the listening socket immediately (only its
+ * callback waits for existing connections to drain), so we can call
+ * `start()` right away to re-bind the port. We also force-close any
+ * lingering keep-alive connections to avoid leaking them on the old
+ * server, which previously caused the port to stay unusable when a
+ * hanging request kept connections open indefinitely.
+ *
  * @method reset
  */
 function reset() {
   try {
     logger.log.info(IDLOG, 'server closing...');
-    server.close(function () {
-      if (reloading === true) {
-        reloading = false;
-        server = undefined;
-        start();
-        logger.log.warn(IDLOG, 'reloaded');
-      }
-    });
+    var oldServer = server;
+    server = undefined;
+
+    oldServer.close();
+    if (typeof oldServer.closeAllConnections === 'function') {
+      try { oldServer.closeAllConnections(); } catch (e) {}
+    }
+
+    if (reloading === true) {
+      reloading = false;
+      start();
+      logger.log.warn(IDLOG, 'reloaded');
+    }
   } catch (err) {
     logger.log.error(IDLOG, err.stack);
   }

--- a/root/usr/lib/node/nethcti-server/plugins/util/util.js
+++ b/root/usr/lib/node/nethcti-server/plugins/util/util.js
@@ -89,6 +89,7 @@ function sendHttp201(parentIdLog, resp) {
     resp.end();
   } catch (err) {
     logger.log.error(IDLOG, 'used by ' + parentIdLog + ': ' + err.stack);
+    try { resp.end(); } catch (e) {}
   }
 }
 
@@ -107,6 +108,7 @@ function sendHttp200(parentIdLog, resp) {
     resp.end();
   } catch (err) {
     logger.log.error(IDLOG, 'used by ' + parentIdLog + ': ' + err.stack);
+    try { resp.end(); } catch (e) {}
   }
 }
 
@@ -129,6 +131,7 @@ function sendHttp400(parentIdLog, resp, params) {
     resp.end();
   } catch (err) {
     logger.log.error(IDLOG, 'used by ' + parentIdLog + ': ' + err.stack);
+    try { resp.end(); } catch (e) {}
   }
 }
 
@@ -147,6 +150,7 @@ function sendHttp404(parentIdLog, resp) {
     resp.end();
   } catch (err) {
     logger.log.error(IDLOG, 'used by ' + parentIdLog + ': ' + err.stack);
+    try { resp.end(); } catch (e) {}
   }
 }
 
@@ -175,6 +179,7 @@ function sendHttp401(parentIdLog, resp, err, code) {
     resp.end();
   } catch (err) {
     logger.log.error(IDLOG, 'used by ' + parentIdLog + ': ' + err.stack);
+    try { resp.end(); } catch (e) {}
   }
 }
 
@@ -196,6 +201,7 @@ function sendHttp401Nonce(parentIdLog, resp, nonce) {
     resp.end();
   } catch (err) {
     logger.log.error(IDLOG, 'used by ' + parentIdLog + ': ' + err.stack);
+    try { resp.end(); } catch (e) {}
   }
 }
 
@@ -214,6 +220,7 @@ function sendHttp403(parentIdLog, resp) {
     resp.end();
   } catch (err) {
     logger.log.error(IDLOG, 'used by ' + parentIdLog + ': ' + err.stack);
+    try { resp.end(); } catch (e) {}
   }
 }
 
@@ -238,6 +245,7 @@ function sendHttp500(parentIdLog, resp, err) {
     resp.end();
   } catch (err) {
     logger.log.error(IDLOG, 'used by ' + parentIdLog + ': ' + err.stack);
+    try { resp.end(); } catch (e) {}
   }
 }
 
@@ -257,6 +265,7 @@ let sendHttp503 = (parentIdLog, resp, reason) => {
     resp.end();
   } catch (err) {
     logger.log.error(IDLOG, 'used by ' + parentIdLog + ': ' + err.stack);
+    try { resp.end(); } catch (e) {}
   }
 };
 


### PR DESCRIPTION
## Summary

The authentication REST listener can become permanently unresponsive after a single internal reload, requiring a full process restart to recover. This change addresses two independent issues that combine to cause it.

### Response not closed on header errors

The `sendHttp*` helpers in `plugins/util/util.js` wrap their body in a `try/catch` but only log the error from the catch — `resp.end()` is never called. If `resp.writeHead()` throws (for example when a value passed to it contains characters not allowed in HTTP header content), the request stays open and the underlying TCP connection is kept alive by the peer.

All `sendHttp*` helpers now best-effort call `resp.end()` from their catch block.

### Listener not re-bound when connections are hanging

`reset()` in `plugins/com_authentication_rest/server_com_authentication_rest.js` called `start()` only inside the `server.close()` callback. The Node.js `close()` callback fires only after every existing connection has ended, so any hanging request (such as one left over by the issue above) is enough to prevent it from firing — and therefore prevents the listener from being re-bound to its port indefinitely.

Two changes:

1. `start()` is now called immediately after `server.close()`. The listening socket is released synchronously by `close()`; only the callback waits for existing connections to drain, so re-binding does not need to wait.
2. `server.closeAllConnections()` is invoked when available (Node ≥ 18.2) to force-close lingering keep-alive connections on the old server, so the previous `Server` instance does not stay around indefinitely.