### PR TITLE
fix(stt): honor satellite_stt profile permission for transcription/summary

### DIFF
--- a/root/usr/lib/node/nethcti-server/plugins/authorization/authorization.js
+++ b/root/usr/lib/node/nethcti-server/plugins/authorization/authorization.js
@@ -430,6 +430,35 @@ function authorizeRecordingUser(username) {
 }
 
 /**
+ * Returns true if the specified user has the Speech-To-Text authorization.
+ *
+ * @method authorizeSttUser
+ * @param  {string}  username The username
+ * @return {boolean} True if the user has the Speech-To-Text authorization.
+ */
+function authorizeSttUser(username) {
+  try {
+    // check parameter
+    if (typeof username !== 'string') {
+      throw new Error('wrong parameters: ' + JSON.stringify(arguments));
+    }
+
+    var profid = getUserProfileId(username);
+
+    return (
+      profiles[profid] !== undefined &&
+      profiles[profid].macro_permissions.nethvoice_cti.value === true &&
+      profiles[profid].macro_permissions.nethvoice_cti.permissions.satellite_stt.value === true
+    );
+
+  } catch (err) {
+    logger.log.error(IDLOG, err.stack);
+    // in the case of exception it returns false for security reasons
+    return false;
+  }
+}
+
+/**
  * Returns true if the specified user has the authorization to view the lost calls of the queues.
  *
  * @method authorizeLostQueueCallsUser
@@ -2189,6 +2218,7 @@ exports.authorizeAdminCdrUser = authorizeAdminCdrUser;
 exports.getUserAuthorizations = getUserAuthorizations;
 exports.authorizeAdminPhoneUser = authorizeAdminPhoneUser;
 exports.authorizeRecordingUser = authorizeRecordingUser;
+exports.authorizeSttUser = authorizeSttUser;
 exports.authorizePhonebookUser = authorizePhonebookUser;
 exports.authorizeStreamingUser = authorizeStreamingUser;
 exports.authorizeRemoteSiteUser = authorizeRemoteSiteUser;

--- a/root/usr/lib/node/nethcti-server/plugins/com_user_rest/plugins_rest/user.js
+++ b/root/usr/lib/node/nethcti-server/plugins/com_user_rest/plugins_rest/user.js
@@ -728,9 +728,13 @@ function setCompUtil(comp) {
               logger.log.info(IDLOG, "Proxy fqdn missing");
             }
 
+            // Speech-To-Text features depend both on the module-level switch
+            // (SATELLITE_* env vars) and on the user's "satellite_stt" profile permission.
+            var hasSttPermission = compAuthorization.authorizeSttUser(username);
+
             // Add call transcriptions status
             var call_transcription_enabled = process.env.SATELLITE_CALL_TRANSCRIPTION_ENABLED;
-            if (call_transcription_enabled && call_transcription_enabled == 'True') {
+            if (hasSttPermission && call_transcription_enabled && call_transcription_enabled == 'True') {
               result.call_transcription_enabled = true;
             } else {
               logger.log.info(IDLOG, "call_transcription_enabled missing");
@@ -746,7 +750,7 @@ function setCompUtil(comp) {
 
             // Add call summary status
             var call_summary_enabled = process.env.SATELLITE_CALL_SUMMARY_ENABLED;
-            if (call_summary_enabled && call_summary_enabled == 'True') {
+            if (hasSttPermission && call_summary_enabled && call_summary_enabled == 'True') {
               result.call_summary_enabled = true;
             } else {
               logger.log.info(IDLOG, "call_summary_enabled missing");


### PR DESCRIPTION
## Problem
The `GET me` user-info response set `call_transcription_enabled` and `call_summary_enabled` purely from the `SATELLITE_*` module env vars, ignoring the per-user `satellite_stt` (Speech-To-Text) profile permission. The CTI/NethLink transcription and summary controls (e.g. the call summary notification option in settings) therefore stayed available for users whose profile had Speech-To-Text disabled.

QA point 2 of NethServer/dev#7143.

## Fix
- Add `authorizeSttUser(username)` in the authorization plugin, checking `macro_permissions.nethvoice_cti.permissions.satellite_stt.value`.
- AND `call_transcription_enabled` and `call_summary_enabled` with that permission in `com_user_rest/plugins_rest/user.js`.

All consumers (CTI, NethLink) realign automatically — no frontend change needed.

## Note
`voicemail_transcription_enabled` is intentionally left unchanged (the `satellite_stt` permission covers call transcription/summary, not voicemail).

Closes NethServer/dev#8038